### PR TITLE
fix: use `tsx` instead of `@swc/node` to make it work regardless of the ESM/CommonJS madhouse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PACKAGE_MANAGER=pnpm
 ENV SWC_NODE_PROJECT $SERVER_PATH/tsconfig.json
 
 # * Install packages that are required for this docker image to run
-RUN npm install -g pnpm nodemon express@$EXPRESS_VERSION morgan glob @swc-node/register typescript @antfu/ni
+RUN npm install -g pnpm nodemon express@$EXPRESS_VERSION morgan glob tsx @antfu/ni
 
 # * The pnpm store should be mounted in the same volume as node_modules (requires hard links)
 # * See https://pnpm.io/6.x/npmrc#store-dir

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,7 +1,9 @@
 {
-  "ignore": ["!(package*.json|pnpm-*.yaml|yarn.lock)"],
+  "ignore": [
+    "!(package*.json|pnpm-*.yaml|yarn.lock)"
+  ],
   "execMap": {
-    "json": "ni && nodemon --ext 'js,ts' -w functions -x 'node -r @swc-node/register' $SERVER_PATH/server.ts"
+    "json": "ni && nodemon --ext 'js,ts' -w functions -x 'tsx' $SERVER_PATH/server.ts"
   },
   "ext": "json,yaml,lock"
 }


### PR DESCRIPTION
Kudos @guicurcio 