### PR TITLE
Ignore node_modules

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -41,14 +41,14 @@ const main = async () => {
 
   for (const file of files) {
     const { default: handler } = await import(path.join(functionsPath, file))
-    // File path relative to the project root directory. Used for logging.
-    const relativePath = path.join(
-      process.env.FUNCTIONS_WORKING_DIR,
-      process.env.FUNCTIONS_RELATIVE_PATH,
-      file
-    )
 
     if (handler) {
+      // File path relative to the project root directory. Used for logging.
+      const relativePath = path.join(
+        process.env.FUNCTIONS_WORKING_DIR,
+        process.env.FUNCTIONS_RELATIVE_PATH,
+        file
+      )
       const route = `/${file}`
         .replace(/(\.ts|\.js)$/, '')
         .replace(/\/index$/, '/')

--- a/server.ts
+++ b/server.ts
@@ -40,8 +40,13 @@ const main = async () => {
   })
 
   for (const file of files) {
-    const filePath = path.join(functionsPath, file)
-    const { default: handler } = await import(filePath)
+    const { default: handler } = await import(path.join(functionsPath, file))
+    // File path relative to the project root directory. Used for logging.
+    const relativePath = path.join(
+      process.env.FUNCTIONS_WORKING_DIR,
+      process.env.FUNCTIONS_RELATIVE_PATH,
+      file
+    )
 
     if (handler) {
       const route = `/${file}`
@@ -51,13 +56,15 @@ const main = async () => {
       try {
         app.all(route, handler)
       } catch (error) {
-        console.warn(`Unable to load file ${filePath} as a Serverless Function`)
+        console.warn(
+          `Unable to load file ${relativePath} as a Serverless Function`
+        )
         continue
       }
 
-      console.log(`Loaded route ${route} from ${filePath}`)
+      console.log(`Loaded route ${route} from ${relativePath}`)
     } else {
-      console.warn(`No default export at ${filePath}`)
+      console.warn(`No default export at ${relativePath}`)
     }
   }
 

--- a/server.ts
+++ b/server.ts
@@ -42,13 +42,10 @@ const main = async () => {
   for (const file of files) {
     const { default: handler } = await import(path.join(functionsPath, file))
 
+    // File path relative to the project root directory. Used for logging.
+    const relativePath = path.relative(process.env.NHOST_PROJECT_PATH, file)
+
     if (handler) {
-      // File path relative to the project root directory. Used for logging.
-      const relativePath = path.join(
-        process.env.FUNCTIONS_WORKING_DIR,
-        process.env.FUNCTIONS_RELATIVE_PATH,
-        file
-      )
       const route = `/${file}`
         .replace(/(\.ts|\.js)$/, '')
         .replace(/\/index$/, '/')

--- a/server.ts
+++ b/server.ts
@@ -34,8 +34,8 @@ const main = async () => {
     cwd: functionsPath,
     ignore: [
       '**/node_modules/**', // ignore node_modules directories
-      '**/_**/*', // ignore files inside directories that starts with _
-      '**/_*' // ignore files that starts with _
+      '**/_**/*', // ignore files inside directories that start with _
+      '**/_*' // ignore files that start with _
     ]
   })
 


### PR DESCRIPTION
- do browse handlers in `node_modules`
- correct logging according to functions relative path
- simplify filtering out files using the `ignore` option