### PR TITLE
fix: ignore tsconfig.json in source

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -3,7 +3,7 @@
     "!(package.json|package-lock.json|pnpm-lock.yaml|yarn.lock)"
   ],
   "execMap": {
-    "json": "cd $FUNCTIONS_WORKING_DIR ; ni ; nodemon --ext 'js,ts' -w $FUNCTIONS_RELATIVE_PATH -x 'tsx' $SERVER_PATH/server.ts"
+    "json": "cd $FUNCTIONS_WORKING_DIR ; ni ; nodemon --ext 'js,ts' -w $FUNCTIONS_RELATIVE_PATH -x 'tsx' --tsconfig $SERVER_PATH/tsconfig.json $SERVER_PATH/server.ts"
   },
   "ext": "json,yaml,lock"
 }


### PR DESCRIPTION
Any file outside of the Nhost project root will be ignored. While it would solve [this issue](https://github.com/nhost/cli/issues/305), the functions container won't work in monorepos when the Nhost project is a subdirectory of the monorepo root.