### PR TITLE
Set max request body size to 6 MBytes

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -18,7 +18,7 @@ const main = async () => {
   )
 
   // * Same settings as in Watchtower
-  app.use(express.json())
+  app.use(express.json({ limit: '6MB' }))
   app.use(express.urlencoded({ extended: true }))
   app.disable('x-powered-by')
 


### PR DESCRIPTION
Set the same max request body size as in the cloud. Reported [issue](https://github.com/nhost/cli/issues/337)