### PR TITLE
Bump express to 4.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:14-alpine
 
 # * Same version as in Watchtower
-ARG EXPRESS_VERSION 4.17.1
+ARG EXPRESS_VERSION=4.18.1
 ENV EXPRESS_VERSION $EXPRESS_VERSION
 
-# * path to the server files 
+# * path to the server files
 ARG SERVER_PATH /opt/server
 ENV SERVER_PATH=$SERVER_PATH
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/glob": "^7.2.0",
     "@types/morgan": "^1.9.3",
     "@types/node": "^18.7.6",
-    "express": "4.17.1",
+    "express": "4.18.1",
     "glob": "^8.0.3",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.19",


### PR DESCRIPTION
Use the same express version as in cloud functions deployer