### PR TITLE
fix: do not watch lock files

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,9 +1,9 @@
 {
   "ignore": [
-    "!(package.json|package-lock.json|pnpm-lock.yaml|yarn.lock)"
+    "!(package.json)"
   ],
   "execMap": {
     "json": "cd $FUNCTIONS_WORKING_DIR ; ni ; nodemon --ext 'js,ts' -w $FUNCTIONS_RELATIVE_PATH -x 'tsx' $SERVER_PATH/server.ts"
   },
-  "ext": "json,yaml,lock"
+  "ext": "json"
 }


### PR DESCRIPTION
will avoid infinite loop when the package manager installs dependencies and modifies the lock file indefinitely.
See https://github.com/nhost/cli/issues/402